### PR TITLE
Update search_bar_demo.dart

### DIFF
--- a/mecury_project/example/beaytiful_search_bar_demo/lib/search_bar_demo.dart
+++ b/mecury_project/example/beaytiful_search_bar_demo/lib/search_bar_demo.dart
@@ -60,7 +60,9 @@ class SearchBarDelegate extends SearchDelegate<String> {
         itemCount: suggestionList.length,
         itemBuilder: (context, index) => ListTile(
 
-          onTap: (){showResults(context);},
+          onTap: (){
+            query = suggestionList[index];
+            showResults(context);},
 
               title: RichText(
                   text: TextSpan(


### PR DESCRIPTION
点击默认的suggestion跳转后显示内容为空